### PR TITLE
Add Actions before and after the output of the Events List

### DIFF
--- a/sugar-event-calendar/includes/themes/legacy/events-list.php
+++ b/sugar-event-calendar/includes/themes/legacy/events-list.php
@@ -96,6 +96,8 @@ function sc_get_events_list( $display = 'upcoming', $category = null, $number = 
 	// Start an output buffer to store these result
 	ob_start();
 
+	do_action( 'sc_before_events_list' );
+
 	// Start an unordered list
 	echo '<ul class="sc_events_list">';
 
@@ -154,6 +156,8 @@ function sc_get_events_list( $display = 'upcoming', $category = null, $number = 
 
 	// Reset post data - we'll be looping through our own
 	wp_reset_postdata();
+
+	do_action( 'sc_after_events_list' );
 
 	// Return the current buffer and delete it
 	return ob_get_clean();


### PR DESCRIPTION
This adds Actions to before and after the Events List similarly to how the Calendar does.

Currently only the Widget has these actions for the Event List, but if you were to call `sc_get_events_list()` directly in your theme template files there would be no Actions before or after the Events List without this change.