### PR TITLE
Also check is_callable() for settings sections

### DIFF
--- a/sugar-event-calendar/includes/admin/settings.php
+++ b/sugar-event-calendar/includes/admin/settings.php
@@ -340,7 +340,7 @@ function section( $section = '', $subsection = 'main' ) {
 		: '';
 
 	// Maybe call the function
-	if ( function_exists( $func ) ) {
+	if ( is_callable( $func ) || function_exists( $func ) ) {
 		call_user_func( $func );
 	}
 }


### PR DESCRIPTION
This small patch allows you to use something like

`'func' => array( $this, 'license_support_output' ),` 

In the `sugar_calendar_settings_subsections` Filter. It doesn't prevent the way that Sugar Calendar Standard/Pro is handling it currently from working, but allows some flexibility for other extensions.