### PR TITLE
Bail early if no array to get a post ID from.

### DIFF
--- a/sugar-event-calendar/includes/events/capabilities.php
+++ b/sugar-event-calendar/includes/events/capabilities.php
@@ -30,6 +30,12 @@ function sugar_calendar_post_meta_caps( $caps = array(), $cap = '', $user_id = 0
 
 		// Deleting
 		case 'delete_event' :
+
+			// Bail if no post ID
+			if ( empty( $args[0] ) ) {
+				break;
+			}
+
 			$post = get_post( $args[0] );
 			if ( ! $post ) {
 				$caps[] = 'do_not_allow';
@@ -80,6 +86,12 @@ function sugar_calendar_post_meta_caps( $caps = array(), $cap = '', $user_id = 0
 
 		// Editing
 		case 'edit_event' :
+
+			// Bail if no post ID
+			if ( empty( $args[0] ) ) {
+				break;
+			}
+
 			$post = get_post( $args[0] );
 			if ( empty( $post ) ) {
 				$caps = array( 'do_not_allow' );
@@ -130,6 +142,12 @@ function sugar_calendar_post_meta_caps( $caps = array(), $cap = '', $user_id = 0
 
 		// Reading
 		case 'read_event' :
+
+			// Bail if no post ID
+			if ( empty( $args[0] ) ) {
+				break;
+			}
+
 			$post = get_post( $args[0] );
 			if ( empty( $post ) ) {
 				$caps = array( 'do_not_allow' );


### PR DESCRIPTION
This commit avoids a debug notice in Sugar Calendar when another plugin mangles the map_meta_cap filter by no longer returning an array.

Props Timi Wahalahti for reporting this to our support team.

Fixes #31.